### PR TITLE
Update miner.cpp

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -2283,7 +2283,6 @@ void GenerateAbcmints(bool fGenerate, CWallet* pwallet)
         return;
 
     minerThreads = new boost::thread_group();
-    nThreads = 1;
     for (int i = 0; i < nThreads; i++)
         minerThreads->create_thread(boost::bind(&AbcmintMiner, pwallet));
 }


### PR DESCRIPTION
Removed nThreads=1 which defaulted the number of threads to one even if more threads are specified using setgenerate option.