### PR TITLE
add control rpc interface for public key scan thread

### DIFF
--- a/src/abcmintrpc.cpp
+++ b/src/abcmintrpc.cpp
@@ -204,6 +204,8 @@ static const CRPCCommand vRPCCommands[] =
     { "getdifficulty",          &getdifficulty,          true,      false },
     { "getgenerate",            &getgenerate,            true,      false },
     { "setgenerate",            &setgenerate,            true,      false },
+    { "getsearchpubkeypos",     &getsearchpubkeypos,     true,      false },
+    { "setsearchpubkeypos",     &setsearchpubkeypos,     true,      false },
     { "gethashespersec",        &gethashespersec,        true,      false },
     { "getinfo",                &getinfo,                true,      false },
     { "getmininginfo",          &getmininginfo,          true,      false },
@@ -1140,6 +1142,8 @@ Array RPCConvertValues(const std::string &strMethod, const std::vector<std::stri
     if (strMethod == "getaddednodeinfo"       && n > 0) ConvertTo<bool>(params[0]);
     if (strMethod == "setgenerate"            && n > 0) ConvertTo<bool>(params[0]);
     if (strMethod == "setgenerate"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "setsearchpubkeypos"     && n > 0) ConvertTo<bool>(params[0]);
+    if (strMethod == "setsearchpubkeypos"     && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "sendtoaddress"          && n > 1) ConvertTo<double>(params[1]);
     if (strMethod == "settxfee"               && n > 0) ConvertTo<double>(params[0]);
     if (strMethod == "getreceivedbyaddress"   && n > 1) ConvertTo<boost::int64_t>(params[1]);

--- a/src/abcmintrpc.h
+++ b/src/abcmintrpc.h
@@ -174,6 +174,8 @@ extern json_spirit::Value walletlock(const json_spirit::Array& params, bool fHel
 extern json_spirit::Value encryptwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value validateaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getsearchpubkeypos(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value setsearchpubkeypos(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);

--- a/src/diskpubkeypos.cpp
+++ b/src/diskpubkeypos.cpp
@@ -247,7 +247,24 @@ void PubKeyScanner(CWallet* pwalletMain)
 }
 
 //more logic extention (offer rpc command to user to control this thread)
-void SearchPubKeyPos(boost::thread_group& threadGroup)
+void SearchPubKeyPos(bool fScan)
 {
-    threadGroup.create_thread(boost::bind(&PubKeyScanner, pwalletMain));
+    static boost::thread_group* scanerThreads = NULL;
+
+    int nThreads = GetArg("-scanerproclimit", -1);
+    if (nThreads < 0)
+        nThreads = 1;
+
+    if (scanerThreads != NULL)
+    {
+        scanerThreads->interrupt_all();
+        delete scanerThreads;
+        scanerThreads = NULL;
+    }
+
+    if (nThreads == 0 || !fScan)
+        return;
+
+    scanerThreads = new boost::thread_group();
+    scanerThreads->create_thread(boost::bind(&PubKeyScanner, pwalletMain));
 }

--- a/src/diskpubkeypos.cpp
+++ b/src/diskpubkeypos.cpp
@@ -236,7 +236,7 @@ void PubKeyScanner(CWallet* pwalletMain)
             } else
                 SetThreadPriority(THREAD_PRIORITY_NORMAL);
 
-            MilliSleep(allPosFound ? 120*60*1000 : 10*60*1000);
+            MilliSleep(allPosFound ? 4*60*60*1000 : 2*60*60*1000);
         }
     }
     catch (boost::thread_interrupted)

--- a/src/diskpubkeypos.h
+++ b/src/diskpubkeypos.h
@@ -99,7 +99,7 @@ bool GetPubKeyByPos(CDiskPubKeyPos pos, CPubKey& pubKey);
 
 bool UpdatePubKeyPos(CPubKey& pubKey, const std::string& address);
 
-void SearchPubKeyPos(boost::thread_group& threadGroup);
+void SearchPubKeyPos(bool fScan);
 
 #endif
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -297,6 +297,7 @@ std::string HelpMessage()
         "  -conf=<file>           " + _("Specify configuration file (default: abcmint.conf)") + "\n" +
         "  -pid=<file>            " + _("Specify pid file (default: abcmint.pid)") + "\n" +
         "  -gen                   " + _("Generate coins (default: 0)") + "\n" +
+        "  -search                " + _("Search public key position (default: 1)") + "\n" +
         "  -datadir=<dir>         " + _("Specify data directory") + "\n" +
         "  -dbcache=<n>           " + _("Set database cache size in megabytes (default: 25)") + "\n" +
         "  -timeout=<n>           " + _("Specify connection timeout in milliseconds (default: 5000)") + "\n" +
@@ -1061,7 +1062,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     GenerateAbcmints(GetBoolArg("-gen", false), pwalletMain);
 
     //seach block position for public key  in the background
-    SearchPubKeyPos(threadGroup);
+    SearchPubKeyPos(GetBoolArg("-search", true));
 
     // ********************************************************* Step 13: finished
 

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1540,3 +1540,38 @@ Value listlockunspent(const Array& params, bool fHelp)
     return ret;
 }
 
+Value getsearchpubkeypos(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getsearchpubkeypos\n"
+            "Returns true or false.");
+
+    return GetBoolArg("-search", true);
+}
+
+Value setsearchpubkeypos(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 2)
+        throw runtime_error(
+            "setsearchpubkeypos <search> [searchproclimit]\n"
+            "<search> is true or false to turn search on or off.\n"
+            "search is limited to [searchproclimit] processors, -1 is unlimited.");
+
+    bool fSearch = true;
+    if (params.size() > 0)
+        fSearch = params[0].get_bool();
+
+    if (params.size() > 1)
+    {
+        int nSearchProcLimit = params[1].get_int();
+        mapArgs["-searchproclimit"] = itostr(nSearchProcLimit);
+        if (nSearchProcLimit == 0)
+            fSearch = false;
+    }
+    mapArgs["-search"] = (fSearch ? "1" : "0");
+
+    SearchPubKeyPos(fSearch);
+    return Value::null;
+}
+


### PR DESCRIPTION
as block growth, scanner may cost lots of CPU, and block synchronize maybe worse
for seed/DNS seed node, this thread should be set to false

consider scan the public key position when accept a new block later