### PR TITLE
gethashespersec is not useful, delete it

### DIFF
--- a/contrib/bitrpc/bitrpc.py
+++ b/contrib/bitrpc/bitrpc.py
@@ -91,12 +91,6 @@ elif cmd == "getgenerate":
 	except:
 		print "\n---An error occurred---\n"
 
-elif cmd == "gethashespersec":
-	try:
-		print access.gethashespersec()
-	except:
-		print "\n---An error occurred---\n"
-
 elif cmd == "getinfo":
 	try:
 		print access.getinfo()

--- a/src/abcmintrpc.cpp
+++ b/src/abcmintrpc.cpp
@@ -206,7 +206,6 @@ static const CRPCCommand vRPCCommands[] =
     { "setgenerate",            &setgenerate,            true,      false },
     { "getsearchpubkeypos",     &getsearchpubkeypos,     true,      false },
     { "setsearchpubkeypos",     &setsearchpubkeypos,     true,      false },
-    { "gethashespersec",        &gethashespersec,        true,      false },
     { "getinfo",                &getinfo,                true,      false },
     { "getmininginfo",          &getmininginfo,          true,      false },
     { "getnewaddress",          &getnewaddress,          true,      false },

--- a/src/abcmintrpc.h
+++ b/src/abcmintrpc.h
@@ -137,7 +137,6 @@ extern json_spirit::Value importkey(const json_spirit::Array& params, bool fHelp
 
 extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHelp); // in rpcmining.cpp
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value gethashespersec(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getmininginfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getwork(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getblocktemplate(const json_spirit::Array& params, bool fHelp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,9 +65,6 @@ map<uint256, set<uint256> > mapOrphanTransactionsByPrev;
 
 const string strMessageMagic = "Abcmint Signed Message:\n";
 
-double dHashesPerSec = 0.0;
-int64 nHPSTimerStart = 0;
-
 // Settings
 int64 nTransactionFee = 0;
 

--- a/src/main.h
+++ b/src/main.h
@@ -77,8 +77,6 @@ extern uint256 hashBestChain;
 extern CBlockIndex* pindexBest;
 extern unsigned int nTransactionsUpdated;
 extern const std::string strMessageMagic;
-extern double dHashesPerSec;
-extern int64 nHPSTimerStart;
 extern int64 nTimeBestReceived;
 extern CCriticalSection cs_setpwalletRegistered;
 extern std::set<CWallet*> setpwalletRegistered;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -49,19 +49,6 @@ Value setgenerate(const Array& params, bool fHelp)
 }
 
 
-Value gethashespersec(const Array& params, bool fHelp)
-{
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "gethashespersec\n"
-            "Returns a recent hashes per second performance measurement while generating.");
-
-    if (GetTimeMillis() - nHPSTimerStart > 8000)
-        return (boost::int64_t)0;
-    return (boost::int64_t)dHashesPerSec;
-}
-
-
 Value getmininginfo(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -77,7 +64,6 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     obj.push_back(Pair("generate",      GetBoolArg("-gen")));
     obj.push_back(Pair("genproclimit",  (int)GetArg("-genproclimit", -1)));
-    obj.push_back(Pair("hashespersec",  gethashespersec(params, false)));
     obj.push_back(Pair("pooledtx",      (uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",       fTestNet));
     return obj;
@@ -132,7 +118,7 @@ Value getwork(const Array& params, bool fHelp)
             nTransactionsUpdatedLast = nTransactionsUpdated;
             CBlockIndex* pindexPrevNew = pindexBest;
             nStart = GetTime();
-            
+
             if(!pMiningKey)
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "not in server mode");
 


### PR DESCRIPTION
POW is based on multivariable equation, not hash, 'gethashespersec' interface is not useful. 

The miner of this coin is using GPU now, CPU miner can't get coin, so the mining interface is not useful either, and we don't need to change 'gethashespersec' in master branch.

Miner should develop their own interface to collect the mining infomation in GPU branches. 